### PR TITLE
Update aws_provider.py for wrong json attribute reference

### DIFF
--- a/cloud_detect/providers/aws_provider.py
+++ b/cloud_detect/providers/aws_provider.py
@@ -32,7 +32,7 @@ class AWSProvider(AbstractProvider):
         self.logger.debug('Checking AWS metadata')
         try:
             response = requests.get(self.metadata_url).json()
-            if response['imageID'].startswith('ami-',) and response[
+            if response['imageId'].startswith('ami-',) and response[
                 'instanceId'
             ].startswith('i-'):
                 return True

--- a/tests/aws_provider_test.py
+++ b/tests/aws_provider_test.py
@@ -24,7 +24,7 @@ def test_valid_metadata_server_check():
     mocking_url = 'http://testing_metadata_url.com'
     responses.add(
         responses.GET, 'http://testing_metadata_url.com',
-        json={'imageID': 'ami-12312412', 'instanceId': 'i-ec12as'},
+        json={'imageId': 'ami-12312412', 'instanceId': 'i-ec12as'},
     )
 
     provider = AWSProvider()
@@ -37,7 +37,7 @@ def test_invalid_metadata_server_check():
     mocking_url = 'http://testing_metadata_url.com'
     responses.add(
         responses.GET, 'http://testing_metadata_url.com',
-        json={'imageID': 'some_ID', 'instanceId': 'some_Instance'},
+        json={'imageId': 'some_ID', 'instanceId': 'some_Instance'},
     )
 
     provider = AWSProvider()


### PR DESCRIPTION
The json response from aws metadata have imageId as a key and not imageID.