### PR TITLE
Use asyncio to speed up cloud identification

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,4 +1,4 @@
-name: Testing for Python Versions 3.5-3.8 via tox
+name: Testing for Python Versions 3.6-3.8 via tox
 on:
   push:
    branches:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.5', '3.6' , '3.7', '3.8' ]
+        python-version: [ '3.6' , '3.7', '3.8' ]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,4 +1,4 @@
-name: Testing for Python Versions 3.6-3.8 via tox
+name: Testing for Python Versions 3.6-3.9 via tox
 on:
   push:
    branches:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.6' , '3.7', '3.8' ]
+        python-version: [ '3.6' , '3.7', '3.8', '3.9' ]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 !.gitignore
 .python-version
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/cloud-detect.svg)](https://pypi.org/project/cloud-detect/)
 [![PyPI](https://img.shields.io/pypi/v/cloud-detect.svg)](https://pypi.org/project/cloud-detect/)
 [![PyPI - License](https://img.shields.io/pypi/l/cloud-detect.svg)](https://github.com/dgzlopes/cloud-detect/blob/master/LICENSE.md)
-[![Build Status](https://github.com/dgzlopes/cloud-detect/workflows/Testing%20for%20Python%20Versions%203.5-3.8%20via%20tox/badge.svg)](https://github.com/dgzlopes/cloud-detect/actions?query=workflow%3A%22Testing+for+Python+Versions+3.5-3.8+via+tox%22)
+[![Build Status](https://github.com/dgzlopes/cloud-detect/workflows/Testing%20for%20Python%20Versions%203.6-3.8%20via%20tox/badge.svg)](https://github.com/dgzlopes/cloud-detect/actions?query=workflow%3A%22Testing+for+Python+Versions+3.6-3.8+via+tox%22)
 
 ## About
 `cloud-detect` is a Python module that determines a host's cloud provider. Highly inspired by the Go based [Satellite](https://github.com/banzaicloud/satellite), `cloud-detect` uses the same techniques (file systems and provider metadata) to properly identify cloud providers.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/cloud-detect.svg)](https://pypi.org/project/cloud-detect/)
 [![PyPI](https://img.shields.io/pypi/v/cloud-detect.svg)](https://pypi.org/project/cloud-detect/)
 [![PyPI - License](https://img.shields.io/pypi/l/cloud-detect.svg)](https://github.com/dgzlopes/cloud-detect/blob/master/LICENSE.md)
-[![Build Status](https://github.com/dgzlopes/cloud-detect/workflows/Testing%20for%20Python%20Versions%203.6-3.8%20via%20tox/badge.svg)](https://github.com/dgzlopes/cloud-detect/actions?query=workflow%3A%22Testing+for+Python+Versions+3.6-3.8+via+tox%22)
+[![Build Status](https://github.com/dgzlopes/cloud-detect/workflows/Testing%20for%20Python%20Versions%203.6-3.9%20via%20tox/badge.svg)](https://github.com/dgzlopes/cloud-detect/actions?query=workflow%3A%22Testing+for+Python+Versions+3.6-3.9+via+tox%22)
 
 ## About
 `cloud-detect` is a Python module that determines a host's cloud provider. Highly inspired by the Go based [Satellite](https://github.com/banzaicloud/satellite), `cloud-detect` uses the same techniques (file systems and provider metadata) to properly identify cloud providers.
 
 ## Features
-- Supports identification of Alibaba, AWS, GCP, Azure and Digital Ocean hosts.
-- Supports skipping providers identification.
+- Supports identification of Alibaba, AWS, Azure, Digital Ocean, GCP and Oracle Cloud hosts.
+- Fast and supports asyncio
 - Logging integration.
 - Small and extensible.
 
@@ -19,11 +19,15 @@
 >>> from cloud_detect import provider
 >>> provider()
 'aws'
->>> provider(excluded='aws')
+
+>>> provider() # when tested in local/non-supported cloud env
 'unknown'
 ```
 
-> Right now the only possible responses are: 'alibaba', 'aws', 'gcp', 'do', 'azure', 'oci' or 'unknown'
+> Right now the only possible responses are: 'alibaba', 'aws', 'azure', 'do', 'gcp', 'oci' or 'unknown'
+
+> You can get the list of supported providers using
+>>`>>> from cloud_detect import SUPPORTED_PROVIDERS`
 
 ## Installation
 Via pip:

--- a/cloud_detect/__init__.py
+++ b/cloud_detect/__init__.py
@@ -1,4 +1,7 @@
+import asyncio
 import logging
+import time
+from sys import version_info
 
 from cloud_detect.providers import AlibabaProvider
 from cloud_detect.providers import AWSProvider
@@ -7,26 +10,65 @@ from cloud_detect.providers import DOProvider
 from cloud_detect.providers import GCPProvider
 from cloud_detect.providers import OCIProvider
 
+__PROVIDER_CLASSES = [
+    AlibabaProvider, AWSProvider, AzureProvider,
+    DOProvider, GCPProvider, OCIProvider,
+]
 
-def provider(excluded=[]):
-    if 'alibaba' not in excluded and AlibabaProvider().identify():
-        logging.debug('Cloud_detect result is alibaba')
-        return 'alibaba'
-    elif 'aws' not in excluded and AWSProvider().identify():
-        logging.debug('Cloud_detect result is aws')
-        return 'aws'
-    elif 'gcp' not in excluded and GCPProvider().identify():
-        logging.debug('Cloud_detect result is gcp')
-        return 'gcp'
-    elif 'do' not in excluded and DOProvider().identify():
-        logging.debug('Cloud_detect result is do')
-        return 'do'
-    elif 'azure' not in excluded and AzureProvider().identify():
-        logging.debug('Cloud_detect result is azure')
-        return 'azure'
-    elif 'oci' not in excluded and OCIProvider().identify():
-        logging.debug('Cloud_detect result is oci')
-        return 'oci'
+TIMEOUT = 5  # seconds
+
+
+async def _identify(timeout):
+    tasks = {
+        prov.identifier: asyncio.ensure_future(
+            prov().identify(),
+        ) for prov in __PROVIDER_CLASSES
+    }
+
+    async def cancel_unfinished_tasks():
+        for t in tasks.values():
+            if not t.done():
+                try:
+                    t.cancel()
+                except asyncio.CancelledError:
+                    pass
+        # This statement ensures
+        # "Task was destroyed but it is pending!" warning is not raised
+        await asyncio.gather(*tasks.values())
+
+    stoptime = time.time() + timeout
+    while tasks and time.time() < stoptime:
+        for prov in list(tasks):
+            t = tasks[prov]
+            if t.done():
+                del tasks[prov]
+                if t.result():
+                    await cancel_unfinished_tasks()
+                    logging.debug('Cloud_detect result is %s' % prov)
+                    return prov
+        else:
+            await asyncio.sleep(0.1)
+            continue
+
+    if tasks:
+        await cancel_unfinished_tasks()
+        return 'timeout'
     else:
-        logging.debug('Cloud_detect result is unknown')
         return 'unknown'
+
+
+def provider(timeout=TIMEOUT):
+    if version_info.minor >= 7:
+        result = asyncio.run(_identify(timeout))
+    else:
+        loop = asyncio.new_event_loop()
+        result = loop.run_until_complete(_identify(timeout))
+        loop.close()
+    return result
+
+
+async def async_provider(timeout=TIMEOUT):
+    return await _identify(timeout)
+
+
+SUPPORTED_PROVIDERS = tuple(sorted(p.identifier for p in __PROVIDER_CLASSES))

--- a/cloud_detect/__init__.py
+++ b/cloud_detect/__init__.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import time
-from sys import version_info
+from sys import version_info as py_version
 
 from cloud_detect.providers import AlibabaProvider
 from cloud_detect.providers import AWSProvider
@@ -44,7 +44,7 @@ async def _identify(timeout):
                 del tasks[prov]
                 if t.result():
                     await cancel_unfinished_tasks()
-                    logging.debug('Cloud_detect result is %s' % prov)
+                    logging.debug(f'Cloud_detect result is {prov}')
                     return prov
         else:
             await asyncio.sleep(0.1)
@@ -58,7 +58,7 @@ async def _identify(timeout):
 
 
 def provider(timeout=TIMEOUT):
-    if version_info.minor >= 7:
+    if py_version.minor >= 7:
         result = asyncio.run(_identify(timeout))
     else:
         loop = asyncio.new_event_loop()

--- a/cloud_detect/providers/oci_provider.py
+++ b/cloud_detect/providers/oci_provider.py
@@ -8,12 +8,13 @@ class OCIProvider(AbstractProvider):
     """
         Concrete implementation of the Oracle Cloud Infrastructure cloud provider.
     """
+    identifier = 'oci'
 
     def __init__(self, logger=None):
         self.logger = logger or logging.getLogger(__name__)
         self.vendor_file = '/sys/class/dmi/id/chassis_asset_tag'
 
-    def identify(self):
+    async def identify(self):
         """
             Tries to identify OCI using all the implemented options
         """

--- a/cloud_detect/providers/provider.py
+++ b/cloud_detect/providers/provider.py
@@ -1,19 +1,20 @@
-from abc import ABCMeta  # noqa: F401
-from abc import abstractmethod  # noqa: F401
+from abc import ABC
+from abc import abstractmethod
 
 
-class AbstractProvider:
+class AbstractProvider(ABC):
     """
         Abstract class representing a cloud provider.
         All concrete cloud providers should implement this.
     """
+    identifier = 'unknown'
 
     @abstractmethod
-    def identify(self):
+    async def identify(self):
         pass  # pragma: no cover
 
     @abstractmethod
-    def check_metadata_server(self):
+    async def check_metadata_server(self):
         pass  # pragma: no cover
 
     @abstractmethod

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ pre-commit==1.11.2
 pytest
 tox>=3.8
 tox-pip-extensions
-responses
+aresponses

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
-import sys
 from distutils.core import setup
+from sys import version_info as py_version
 
 long_description = ''
 try:
@@ -9,13 +9,10 @@ try:
 except FileNotFoundError:
     pass
 
-minor_version = sys.version_info.minor
-if minor_version >= 7:
+if py_version.minor >= 7:
     install_requires = ['aiohttp>=3.7']
-elif minor_version == 6:
-    install_requires = ['aiohttp>=3.7,<4']
 else:
-    install_requires = ['aiohttp>=3.5,<3.7']
+    install_requires = ['aiohttp>=3.7,<4']
 
 setup(
     name='cloud-detect',
@@ -30,7 +27,6 @@ setup(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -41,7 +37,7 @@ setup(
         'Topic :: System :: Systems Administration',
         'Topic :: System :: Networking',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     author='Daniel Gonzalez Lopes',
     author_email='danielgonzalezlopes@gmail.com',
     packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from distutils.core import setup
-
 import setuptools
+import sys
+from distutils.core import setup
 
 long_description = ''
 try:
@@ -8,6 +8,14 @@ try:
         long_description = f.read()
 except FileNotFoundError:
     pass
+
+minor_version = sys.version_info.minor
+if minor_version >= 7:
+    install_requires = ['aiohttp>=3.7']
+elif minor_version == 6:
+    install_requires = ['aiohttp>=3.7,<4']
+else:
+    install_requires = ['aiohttp>=3.5,<3.7']
 
 setup(
     name='cloud-detect',
@@ -17,24 +25,23 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/dgzlopes/cloud-detect',
     license='MIT',
-    install_requires=[
-        'requests>=2.21.0,<3',
-    ],
+    install_requires=install_requires,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Systems Administration',
         'Topic :: System :: Networking',
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     author='Daniel Gonzalez Lopes',
     author_email='danielgonzalezlopes@gmail.com',
     packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-import setuptools
 from distutils.core import setup
 from sys import version_info as py_version
+
+import setuptools
 
 long_description = ''
 try:

--- a/tests/aws_provider_test.py
+++ b/tests/aws_provider_test.py
@@ -1,6 +1,4 @@
 import pytest   # noqa: F401
-import requests   # noqa: F401
-import responses
 
 from cloud_detect.providers import AWSProvider
 
@@ -19,27 +17,27 @@ def test_reading_invalid_vendor_file():
     assert provider.check_vendor_file() is False
 
 
-@responses.activate
-def test_valid_metadata_server_check():
-    mocking_url = 'http://testing_metadata_url.com'
-    responses.add(
-        responses.GET, 'http://testing_metadata_url.com',
-        json={'imageId': 'ami-12312412', 'instanceId': 'i-ec12as'},
+@pytest.mark.asyncio
+async def test_valid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET',
+        response={'imageId': 'ami-12312412', 'instanceId': 'i-ec12as'},
     )
 
     provider = AWSProvider()
-    provider.metadata_url = mocking_url
-    assert provider.check_metadata_server() is True
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is True
 
 
-@responses.activate
-def test_invalid_metadata_server_check():
-    mocking_url = 'http://testing_metadata_url.com'
-    responses.add(
-        responses.GET, 'http://testing_metadata_url.com',
-        json={'imageId': 'some_ID', 'instanceId': 'some_Instance'},
+@pytest.mark.asyncio
+async def test_invalid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET',
+        response={'imageId': 'some_ID', 'instanceId': 'some_Instance'},
     )
 
     provider = AWSProvider()
-    provider.metadata_url = mocking_url
-    assert provider.check_metadata_server() is False
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is False

--- a/tests/azure_provider_test.py
+++ b/tests/azure_provider_test.py
@@ -1,6 +1,4 @@
 import pytest   # noqa: F401
-import requests   # noqa: F401
-import responses   # noqa: F401
 
 from cloud_detect.providers import AzureProvider
 
@@ -19,14 +17,13 @@ def test_reading_invalid_vendor_file():
     assert provider.check_vendor_file() is False
 
 
-@responses.activate
-def test_invalid_metadata_server_check():
-    mocking_url = 'http://testing_metadata_url.com'
-    responses.add(
-        responses.GET, 'http://testing_metadata_url.com',
-        json={},
+@pytest.mark.asyncio
+async def test_invalid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET', response={},
     )
 
     provider = AzureProvider()
-    provider.metadata_url = mocking_url
-    assert provider.check_metadata_server() is True
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is True

--- a/tests/do_provider_test.py
+++ b/tests/do_provider_test.py
@@ -1,6 +1,4 @@
 import pytest   # noqa: F401
-import requests   # noqa: F401
-import responses   # noqa: F401
 
 from cloud_detect.providers import DOProvider
 
@@ -19,27 +17,25 @@ def test_reading_invalid_vendor_file():
     assert provider.check_vendor_file() is False
 
 
-@responses.activate
-def test_valid_metadata_server_check():
-    mocking_url = 'http://testing_metadata_url.com'
-    responses.add(
-        responses.GET, 'http://testing_metadata_url.com',
-        json={'droplet_id': 12312451},
+@pytest.mark.asyncio
+async def test_valid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET', response={'droplet_id': 12312451},
     )
 
     provider = DOProvider()
-    provider.metadata_url = mocking_url
-    assert provider.check_metadata_server() is True
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is True
 
 
-@responses.activate
-def test_invalid_metadata_server_check():
-    mocking_url = 'http://testing_metadata_url.com'
-    responses.add(
-        responses.GET, 'http://testing_metadata_url.com',
-        json={},
+@pytest.mark.asyncio
+async def test_invalid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET', response={},
     )
 
     provider = DOProvider()
-    provider.metadata_url = mocking_url
-    assert provider.check_metadata_server() is False
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is False

--- a/tests/gcp_provider_test.py
+++ b/tests/gcp_provider_test.py
@@ -1,6 +1,4 @@
 import pytest   # noqa: F401
-import requests   # noqa: F401
-import responses   # noqa: F401
 
 from cloud_detect.providers import GCPProvider
 
@@ -19,14 +17,13 @@ def test_reading_invalid_vendor_file():
     assert provider.check_vendor_file() is False
 
 
-@responses.activate
-def test_invalid_metadata_server_check():
-    mocking_url = 'http://testing_metadata_url.com'
-    responses.add(
-        responses.GET, 'http://testing_metadata_url.com',
-        json={},
+@pytest.mark.asyncio
+async def test_invalid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET', response={},
     )
 
     provider = GCPProvider()
-    provider.metadata_url = mocking_url
-    assert provider.check_metadata_server() is True
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is True

--- a/tests/provider_test.py
+++ b/tests/provider_test.py
@@ -1,0 +1,93 @@
+import asyncio
+
+import pytest   # noqa: F401
+
+import cloud_detect
+from cloud_detect.providers import AbstractProvider
+
+
+def test_supported_providers():
+    assert cloud_detect.SUPPORTED_PROVIDERS == \
+        ('alibaba', 'aws', 'azure', 'do', 'gcp', 'oci')
+
+
+def test_provider(monkeypatch):
+    async def mockreturn(t):
+        return 'cloudy'
+
+    monkeypatch.setattr(cloud_detect, '_identify', mockreturn)
+
+    assert cloud_detect.provider() == 'cloudy'
+
+
+@pytest.mark.asyncio
+async def test_async_provider(monkeypatch):
+    async def mockreturn(t):
+        return 'cloudy'
+
+    monkeypatch.setattr(cloud_detect, '_identify', mockreturn)
+
+    assert await cloud_detect.async_provider() == 'cloudy'
+
+
+class BaseTestProviderClass(AbstractProvider):
+
+    def __init__(self, logger=None):
+        self.server_response = None
+        self.file_response = None
+        self.delay = None
+
+    async def identify(self):
+        return self.check_vendor_file() or await self.check_metadata_server()
+
+    async def check_metadata_server(self):
+        await asyncio.sleep(self.delay)
+        return self.server_response
+
+    def check_vendor_file(self):
+        return self.file_response
+
+
+def create_test_provider_class(name, server_response=True, file_respone=True, delay=0.25):
+    class TPC(BaseTestProviderClass):
+        identifier = name
+
+        def __init__(self, logger=None):
+            self.server_response = server_response
+            self.file_response = file_respone
+            self.delay = delay
+
+    return TPC
+
+
+@pytest.mark.asyncio
+async def test_identify(monkeypatch):
+    mock_pcs = []
+    for args in [('c1', True, True), ('c2', False, False)]:
+        mock_pcs.append(create_test_provider_class(*args))
+
+    monkeypatch.setattr(cloud_detect, '__PROVIDER_CLASSES', mock_pcs)
+
+    assert await cloud_detect._identify(0.5) == 'c1'
+
+
+@pytest.mark.asyncio
+async def test_identify_timeout(monkeypatch):
+    mock_pcs = []
+    for args in [('c1', False, False, 1), ('c2', False, False, 3)]:
+        mock_pcs.append(create_test_provider_class(*args))
+
+    monkeypatch.setattr(cloud_detect, '__PROVIDER_CLASSES', mock_pcs)
+
+    assert await cloud_detect._identify(0.5) == 'timeout'
+
+
+@pytest.mark.asyncio
+async def test_identify_unknown(monkeypatch):
+    mock_pcs = []
+    for args in [('c1', False, False, 0.2), ('c2', False, False, 0.2)]:
+        mock_pcs.append(create_test_provider_class(*args))
+
+    monkeypatch.setattr(cloud_detect, '__PROVIDER_CLASSES', mock_pcs)
+
+    assert await cloud_detect._identify(0.5) == 'unknown'

--- a/tests/provider_test.py
+++ b/tests/provider_test.py
@@ -72,6 +72,23 @@ async def test_identify(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_identify_assertion_error():
+    timeout = 0.01
+    with pytest.raises(
+        AssertionError,
+        match=f'`timeout` should be a number and > 0.1, provided value: {timeout}',
+    ):
+        await cloud_detect._identify(timeout)
+
+    timeout = '0'
+    with pytest.raises(
+        AssertionError,
+        match=f'`timeout` should be a number and > 0.1, provided value: {timeout}',
+    ):
+        await cloud_detect._identify(timeout)
+
+
+@pytest.mark.asyncio
 async def test_identify_timeout(monkeypatch):
     mock_pcs = []
     for args in [('c1', False, False, 1), ('c2', False, False, 3)]:
@@ -79,7 +96,7 @@ async def test_identify_timeout(monkeypatch):
 
     monkeypatch.setattr(cloud_detect, '__PROVIDER_CLASSES', mock_pcs)
 
-    assert await cloud_detect._identify(0.5) == 'timeout'
+    assert await cloud_detect._identify(0.5) == 'unknown'
 
 
 @pytest.mark.asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,pre-commit
+envlist = py36,py37,py38,py39,pre-commit
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 
@@ -16,7 +16,6 @@ commands = pre-commit run --all-files
 
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,py38,pre-commit
+envlist = py35,py36,py37,py38,py39,pre-commit
 skip_missing_interpreters = true
 tox_pip_extensions_ext_venv_update = true
 
@@ -20,3 +20,4 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
+    3.9: py39


### PR DESCRIPTION
Implements https://github.com/dgzlopes/cloud-detect/issues/11

Uses `asyncio` to check all the cloud providers concurrently and returns back a response as soon as the cloud provider is detected.  

**Important changes:**
 - Replaced `requests` with `aiohttp` in the dependencies
 - Removed Python 3.4 and 3.5 support.
 - Added `identifier` class variable to each `*Provider` class
 - Added `SUPPORTED_PROVIDERS` api - it's a tuple of `identifier` values of each Provider class
 - Added support for Python 3.9 - the code and test cases are working

I manually tested the changes in Azure and GCP, it's working fine and the response comes back within a second.