### PR TITLE
Fix AWS detection

### DIFF
--- a/cloud_detect/providers/aws_provider.py
+++ b/cloud_detect/providers/aws_provider.py
@@ -34,7 +34,7 @@ class AWSProvider(AbstractProvider):
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(self.metadata_url) as response:
-                    response = await response.json()
+                    response = await response.json(content_type=None)
                     if response['imageId'].startswith('ami-',) and response[
                         'instanceId'
                     ].startswith('i-'):


### PR DESCRIPTION
Handling #15, In some cases, AWS metadata returns `Content-Type: text/plain`