### PR TITLE
Add OpenStack provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 `cloud-detect` is a Python module that determines a host's cloud provider. Highly inspired by the Go based [Satellite](https://github.com/banzaicloud/satellite), `cloud-detect` uses the same techniques (file systems and provider metadata) to properly identify cloud providers.
 
 ## Features
-- Supports identification of Alibaba, AWS, Azure, Digital Ocean, GCP, Oracle Cloud and Vultr hosts.
+- Supports identification of Alibaba, AWS, Azure, Digital Ocean, GCP, Oracle Cloud, OpenStack and Vultr hosts.
 - Fast and supports asyncio
 - Logging integration.
 - Small and extensible.
@@ -24,7 +24,7 @@
 'unknown'
 ```
 
-> Right now the only possible responses are: 'alibaba', 'aws', 'azure', 'do', 'gcp', 'oci', 'vultr' or 'unknown'
+> Right now the only possible responses are: 'alibaba', 'aws', 'azure', 'do', 'gcp', 'oci', 'openstack', 'vultr' or 'unknown'
 
 > You can get the list of supported providers using
 >>`>>> from cloud_detect import SUPPORTED_PROVIDERS`

--- a/cloud_detect/__init__.py
+++ b/cloud_detect/__init__.py
@@ -10,10 +10,12 @@ from cloud_detect.providers import DOProvider
 from cloud_detect.providers import GCPProvider
 from cloud_detect.providers import OCIProvider
 from cloud_detect.providers import VultrProvider
+from cloud_detect.providers import OpenStackProvider
 
 __PROVIDER_CLASSES = [
     AlibabaProvider, AWSProvider, AzureProvider,
-    DOProvider, GCPProvider, OCIProvider, VultrProvider,
+    DOProvider, GCPProvider, OCIProvider,
+    OpenStackProvider, VultrProvider,
 ]
 
 

--- a/cloud_detect/providers/__init__.py
+++ b/cloud_detect/providers/__init__.py
@@ -6,3 +6,4 @@ from .do_provider import DOProvider  # noqa: F401 noreorder
 from .azure_provider import AzureProvider  # noqa: F401 noreorder
 from .oci_provider import OCIProvider  # noqa: F401 noreorder
 from .vultr_provider import VultrProvider # noqa: F401 noreorder
+from .openstack_provider import OpenStackProvider # noqa: F401 noreorder

--- a/cloud_detect/providers/openstack_provider.py
+++ b/cloud_detect/providers/openstack_provider.py
@@ -1,0 +1,59 @@
+import logging
+from pathlib import Path
+
+import aiohttp
+
+from . import AbstractProvider
+
+
+class OpenStackProvider(AbstractProvider):
+    """
+        Concrete implementation of the OpenStack cloud provider.
+    """
+    identifier = 'openstack'
+
+    def __init__(self, logger=None):
+        self.logger = logger or logging.getLogger(__name__)
+        self.metadata_url = 'http://169.254.169.254/openstack'
+        self.vendor_files = (
+            '/sys/class/dmi/id/product_name',
+            '/sys/class/dmi/id/chassis_asset_tag',
+        )
+
+    async def identify(self):
+        """
+            Tries to identify OpenStack using all the implemented options
+        """
+        self.logger.info('Try to identify OpenStack')
+        return self.check_vendor_file() or await self.check_metadata_server()
+
+    async def check_metadata_server(self):
+        """
+            Tries to identify OpenStack via metadata server
+        """
+        self.logger.debug('Checking OpenStack metadata')
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(self.metadata_url) as response:
+                    return response.status == 200
+        except aiohttp.ClientError as e:  # noqa: F841
+            return False
+
+    def check_vendor_file(self):
+        """
+            Tries to identify OpenStack provider by reading the /sys/class/dmi/id/product_name
+        """
+        self.logger.debug('Checking OpenStack vendor file')
+        for vendor_file in self.vendor_files:
+            openstack_path = Path(vendor_file)
+            if openstack_path.is_file():
+                if any(name in openstack_path.read_text() for name in (
+                    "Openstack Nova",
+                    "OpenStack Compute",
+                    "HUAWEICLOUD",
+                    "OpenTelekomCloud",
+                    "SAP CCloud VM",
+                    "OpenStack Nova",
+                )):
+                    return True
+        return False

--- a/tests/openstack_provider_test.py
+++ b/tests/openstack_provider_test.py
@@ -1,0 +1,47 @@
+import pytest   # noqa: F401
+
+from cloud_detect.providers import OpenStackProvider
+
+
+def test_reading_correct_vendor_file_product_name():
+    provider = OpenStackProvider()
+    provider.vendor_files = ('tests/provider_files/openstack_product_name',)
+    assert provider.check_vendor_file() is True
+
+
+def test_reading_correct_vendor_file_chassis_asset_tag():
+    provider = OpenStackProvider()
+    provider.vendor_files = ('tests/provider_files/openstack_chassis_asset_tag',)
+    assert provider.check_vendor_file() is True
+
+
+def test_reading_invalid_vendor_file():
+    provider = OpenStackProvider()
+    provider.vendor_files = ('tests/provider_files/gcp',)
+    assert provider.check_vendor_file() is False
+    provider.vendor_files = ('',)
+    assert provider.check_vendor_file() is False
+
+
+@pytest.mark.asyncio
+async def test_valid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET', response={},
+    )
+
+    provider = OpenStackProvider()
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is True
+
+
+@pytest.mark.asyncio
+async def test_invalid_metadata_server_check(aresponses):
+    mock_host = 'testing_metadata_url.com'
+    aresponses.add(
+        mock_host, '/', 'GET', aresponses.Response(text='error', status=404),
+    )
+
+    provider = OpenStackProvider()
+    provider.metadata_url = f'https://{mock_host}'
+    assert await provider.check_metadata_server() is False

--- a/tests/provider_files/openstack_chassis_asset_tag
+++ b/tests/provider_files/openstack_chassis_asset_tag
@@ -1,0 +1,1 @@
+OpenStack Compute

--- a/tests/provider_files/openstack_product_name
+++ b/tests/provider_files/openstack_product_name
@@ -1,0 +1,1 @@
+Openstack Nova

--- a/tests/provider_test.py
+++ b/tests/provider_test.py
@@ -8,7 +8,7 @@ from cloud_detect.providers import AbstractProvider
 
 def test_supported_providers():
     assert cloud_detect.SUPPORTED_PROVIDERS == \
-        ('alibaba', 'aws', 'azure', 'do', 'gcp', 'oci', 'vultr')
+        ('alibaba', 'aws', 'azure', 'do', 'gcp', 'oci', 'openstack', 'vultr')
 
 
 def test_provider(monkeypatch):


### PR DESCRIPTION
I've added support for detecting OpenStack, based on the "Discovery" section specified here: [https://cloudinit.readthedocs.io/en/latest/reference/datasources/openstack.html#discovery](https://cloudinit.readthedocs.io/en/latest/reference/datasources/openstack.html#discovery)

Note that my code does not check `/proc/1/environ` as specified in the document, as reading this file requires superuser privileges.

I've tested these changes on an OpenStack VM (OpenMetal).